### PR TITLE
Restore clipboard text

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   printWidth: 120,
   tabWidth: 2,
-  semi: false,
-  singleQuote: true,
+  semi: true,
+  singleQuote: false,
   trailingComma: "es5",
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,8 +24,10 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate() {}
 
 async function openToOtherEditorGroup(): Promise<void> {
+  const clipboardTextBefore = await vscode.env.clipboard.readText();
   await vscode.commands.executeCommand("copyFilePath");
   const filename = await vscode.env.clipboard.readText();
+  await vscode.env.clipboard.writeText(clipboardTextBefore);
 
   let uri: vscode.Uri;
   try {


### PR DESCRIPTION
When we use `Open to Other Editor Group` command, the clipboard text is overwritten by the file path to open because of `vscode.commands.executeCommand("copyFilePath")`.

I solved this problem  by restoring the clipboard text.